### PR TITLE
bugfix: ESC keyCode should be 27 and not 127

### DIFF
--- a/src/quick.js
+++ b/src/quick.js
@@ -759,7 +759,7 @@
 			"F5" : 116,
 			"F11" : 122,
 			"F12" : 123,
-			"ESC" : 127
+			"ESC" : 27
 		};
 
 		var KeyToCommandMap = {};


### PR DESCRIPTION
I mentioned this in an issue a little while ago, and decided to just fork, fix, and submit a pull request.